### PR TITLE
fix onstop warning

### DIFF
--- a/plugins/music_service/cdplayer/index.ts
+++ b/plugins/music_service/cdplayer/index.ts
@@ -78,7 +78,7 @@ class ControllerCdio {
         // Once the Plugin has successfull stopped resolve the promise
         defer.resolve();
     
-        return libQ.promise;
+        return defer.promise;
     }
 
     public onRestart () {


### PR DESCRIPTION
As originally mentioned [here](https://volumio.org/forum/player-t7546-10.html#p38352), turning off the plugin issues a promise warning on Volumio UI. Returning the resolved promise fixes that.

BTW: on generated plugin .zip folder, you may want to remove extra `*.ts` and `*.map` files