### PR TITLE
Use consitently Audio CD in UI

### DIFF
--- a/plugins/music_service/cdplayer/index.ts
+++ b/plugins/music_service/cdplayer/index.ts
@@ -225,7 +225,7 @@ class ControllerCdio {
                     uri: 'cdio'
                 },
                 lists: [{
-                    "title": "CD Player",
+                    "title": "Audio CD",
                     "icon": "fa fa-folder-open-o",
                     "availableListViews": ["list","grid"],
                     "items": []


### PR DESCRIPTION
follow-up from https://github.com/geeks-r-us/volumio-plugins/pull/4, actually stick to `Audio CD` as in top browse menu